### PR TITLE
Generate dummy package.json in build/native/src to pass geos conftest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,6 @@ $(GEOS_SRC)/Makefile: $(GEOS_SRC)/configure
 $(GEOS_SRC)/configure:
 	mkdir -p $(SRC_DIR); \
 	cd $(SRC_DIR); \
+	echo "{}" > package.json; \
 	wget -nc $(GEOS_URL); \
 	tar -xf geos-$(GEOS_VERSION).tar.bz2;


### PR DESCRIPTION
Thanks for this exciting project!

When I tried to build by `make` command, I encountered the following error.
```bash
$ npm install
$ make
:
checking whether we are cross compiling... configure: error: in `/home/sanak/Build/wasm/geos-wasm/build/native/src/geos-3.9.4':
configure: error: cannot run C compiled programs.
If you meant to cross compile, use `--host'.
See `config.log' for more details
emconfigure: error: './configure --prefix=/home/sanak/Build/wasm/geos-wasm/build/native/usr --enable-shared=no --disable-inline' failed (returned 77)
make: *** [Makefile:48: build/native/src/geos-3.9.4/Makefile] エラー 1
```

And I found the following `conftest` error in `build/native/src/geos-3.9.4/config.log`.
```
configure:4643: checking whether we are cross compiling
configure:4651: /home/sanak/Build/wasm/emsdk/upstream/emscripten/emcc -o conftest -O3 -fexceptions -DRENAME_INTERNAL_LIBTIFF_SYMBOLS -s ERROR_ON_UNDEFINED_SYMBOLS=0   conftest.c  >&5
configure:4655: $? = 0
configure:4662: ./conftest
node:internal/errors:478
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension "" for /home/sanak/Build/wasm/geos-wasm/build/native/src/geos-3.9.4/conftest. Loading extensionless files is not supported inside of "type":"module" package.json contexts. The package.json file /home/sanak/Build/wasm/geos-wasm/package.json caused this "type":"module" context. Try changing /home/sanak/Build/wasm/geos-wasm/build/native/src/geos-3.9.4/conftest to have a file extension. Note the "bin" field of package.json can point to a file with an extension, for example {"type":"module","bin":{"conftest":"./build/native/src/geos-3.9.4/conftest.js"}}
    at new NodeError (node:internal/errors:387:5)
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:75:11)
    at defaultGetFormat (node:internal/modules/esm/get_format:117:38)
    at defaultLoad (node:internal/modules/esm/load:81:20)
    at nextLoad (node:internal/modules/esm/loader:163:28)
    at ESMLoader.load (node:internal/modules/esm/loader:605:26)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:457:22)
    at new ModuleJob (node:internal/modules/esm/module_job:63:26)
    at ESMLoader.#createModuleJob (node:internal/modules/esm/loader:480:17)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:434:34) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
```

After removing `"type": "module",` line in `package.json`,  the above error was disappeared, but I am not sure whether this fix affect later process, so reviewing this PR is helpful. 🙇‍♂️